### PR TITLE
add .parquet format

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: khfunctions
 Title: Data processing for FHP/OVP
-Version: 1.0.9
+Version: 1.0.10
 Authors@R: 
     person("Vegard", "Lysne", , "vegard.lysne@helsedir.no", role = c("aut", "cre"))
 Description: What the package does (one paragraph).
@@ -26,7 +26,8 @@ Imports:
     zoo (>= 1.8.14),
     data.table (>= 1.17.2),
     stringi (>= 1.8.7),
-    beepr (>= 2.0)
+    beepr (>= 2.0),
+    arrow
 Suggests: 
     methods,
     remotes,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# khfunctions 1.0.10
+* Implemented `.parquet`-format. Filegroups are now saved as .parquet in addition to .rds. 
+* `read_filegroup()` now prioritizes reading from PARQUET folder
+* `read_original_file()` gains the ability to read .parquet files (FORMAT must be 'PARQUET'). When orgdata produces parquet files, this will be more efficient.
+* Bugfix: fix_column_name_pre_stata is no longer failing due to encoding
+
 # khfunctions 1.0.9
 * Fix: cube files was saved with wrong name
 

--- a/R/filegroup_check_original_files.R
+++ b/R/filegroup_check_original_files.R
@@ -49,10 +49,11 @@ check_if_files_exists_and_are_readable <- function(files){
 
 check_if_format_is_ok <- function(read_parameters){
   read_parameters[, FORMAT := toupper(FORMAT)]
-  not_valid_format <- read_parameters[FORMAT %notin% c(c("CSV", "XLS", "XLSX", "SPSS"))]
+  not_valid_format <- read_parameters[FORMAT %notin% c(c("CSV", "XLS", "XLSX", "SPSS", "PARQUET"))]
   mismatch_extension <- read_parameters[FORMAT == "CSV" & !grepl(".csv$", FILNAVN) |
                                   FORMAT %in% c("XLS", "XSLX") & !grepl(".xls$|.xlsx$", FILNAVN)|
-                                  FORMAT == "SPSS" & !grepl(".sav$", FILNAVN)]
+                                  FORMAT == "SPSS" & !grepl(".sav$", FILNAVN) |
+                                  FORMAT == "PARQUET" & !grepl(".parquet$", FILNAVN)]
   if(nrow(not_valid_format) == 0 | nrow(mismatch_extension) == 0){
     cat("\n** Alle filformater ok og korresponderer med filnavn")
     return(invisible(NULL))

--- a/R/filegroup_check_original_files.R
+++ b/R/filegroup_check_original_files.R
@@ -1,6 +1,5 @@
 filegroup_check_original_files_and_spec <- function(parameters){
   cat("\n* SJEKK AV ORIGINALFILER OG PARAMETRE")
-  parameters$read_parameters
   checks <- list()
   checks[["FILER_FINNES"]] <- check_if_files_exists_and_are_readable(files = parameters$read_parameters$filepath)
   checks[["FORMAT_OK"]] <- check_if_format_is_ok(read_parameters = parameters$read_parameters)
@@ -18,7 +17,7 @@ filegroup_check_original_files_and_spec <- function(parameters){
       cat(checks[[1]])
     }
     # sink()
-    stop("FEIL funnet i originalfiler eller innlesingsspecs, se feillogg for oversikt")
+    stop("FEIL funnet i originalfiler eller innlesingsspecs. Sjekk `sessionInfo()` og se om locale = [...]NO.UTF-8. Hvis ikke, kjør `Sys.setlocale('LC_ALL', 'nb-NO.UTF-8')` og prøv igjen")
   } else {
     cat("\n* ALLE SJEKKER FERDIG OG OK!")
   }
@@ -37,7 +36,7 @@ check_if_files_exists_and_are_readable <- function(files){
       not_readable <- c(not_readable, sub(getOption("khfunctions.root"), "", file))
     }
   }
-  if(length(not_exist) == 0 || length(not_readable) == 0){
+  if(length(not_exist) == 0 && length(not_readable) == 0){
     cat("\n** Alle filer eksisterer og kan leses")
     return(invisible(NULL))
   } 

--- a/R/make_table_from_file.R
+++ b/R/make_table_from_file.R
@@ -146,9 +146,32 @@ check_if_all_columns_exist <- function(dt, filecolumns){
 #' @param dt data
 #' @noRd
 convert_all_columns_to_character <- function(dt){
+  orgcolorder <- data.table::copy(names(dt))
   non_char_cols <- names(dt)[!sapply(dt, is.character)]
-  if(length(non_char_cols) > 0) dt[, names(.SD) := lapply(.SD, as.character), .SDcols = non_char_cols]
+  if(length(non_char_cols) > 0){
+    for(col in non_char_cols){
+      dt[, tempvar := as.character(get(col)), by = col][, (col) := NULL]
+      data.table::setnames(dt, "tempvar", col)
+    }
+  }
+  data.table::setcolorder(dt, orgcolorder)
 }
+
+# convert_to_integer_if_possible <- function(dt, cols){
+#   orgcolorder <- data.table::copy(names(dt))
+#   convert <- character()
+#   for(col in cols){
+#     if(all.equal(dt[[col]], as.integer(dt[[col]]))) convert <- c(convert, col)
+#   }
+#   if(length(convert) > 0){
+#     for(col in convert){
+#       dt[, tempvar := as.integer(get(col)), by = col]
+#       dt[, (col) := NULL]
+#       data.table::setnames(dt, "tempvar", col)
+#     }
+#   }
+#   data.table::setcolorder(dt, orgcolorder)
+# }
 
 do_convert_na_to_empty <- function(dt){
   dt[, names(.SD) := lapply(.SD, function(x) data.table::fifelse(is.na(x), "", x))]

--- a/R/read_original_file.R
+++ b/R/read_original_file.R
@@ -82,13 +82,13 @@ do_read_parquet <- function(filepath){
 #' @param filedescription file description
 #' @keywords internal
 #' @noRd
-do_read_qs <- function(filedescription){
-  nthreads <- parallel::detectCores()
-  file <- try(qs2::qs_read(file = filedescription$filepath, nthreads = nthreads))
-  if("try-error" %in% class(file)) stop("Error when reading file: ", filedescription$FILNAVN)
-  # convert_all_columns_to_character(file)
-  return(file)
-}
+# do_read_qs <- function(filedescription){
+#   nthreads <- parallel::detectCores()
+#   file <- try(qs2::qs_read(file = filedescription$filepath, nthreads = nthreads))
+#   if("try-error" %in% class(file)) stop("Error when reading file: ", filedescription$FILNAVN)
+#   # convert_all_columns_to_character(file)
+#   return(file)
+# }
 
 #' @noRd
 do_read_spss <- function(filedescription){

--- a/R/write_output.R
+++ b/R/write_output.R
@@ -27,7 +27,7 @@ write_filegroup_output <- function(dt, parameters){
 #' @noRd
 do_write_parquet <- function(dt, filepath){
   attremove <- grep("^(class|names)$", names(attributes(dt)), value = T, invert = T)
-  for(att in attrmove) data.table::setattr(dt, att, NULL)
+  for(att in attremove) data.table::setattr(dt, att, NULL)
   arrow::write_parquet(dt, sink = filepath, compression = "snappy")
 }
 

--- a/R/write_output.R
+++ b/R/write_output.R
@@ -8,12 +8,27 @@ write_filegroup_output <- function(dt, parameters){
   if(!parameters$write) return(invisible(NULL))
   cat("SAVING OUTPUT FILES:\n")
   root <- getOption("khfunctions.root")
+  parquet <- file.path(root, getOption("khfunctions.filegroups.parquet"), paste0(parameters$name, ".parquet"))
   nyeste <- file.path(root, getOption("khfunctions.filegroups.ny"), paste0(parameters$name, ".rds"))
   datert <- file.path(root, getOption("khfunctions.filegroups.dat"), paste0(parameters$name, "_", parameters$batchdate, ".rds"))
   saveRDS(dt, file = nyeste)
   cat("\n", nyeste)
   file.copy(from = nyeste, to = datert)
   cat("\n", datert)
+  do_write_parquet(dt = dt, filepath = parquet)
+}
+
+#' @title do_write_parquet
+#' @description
+#' Wrapper around arrow::write_parquet which first strips away all unneccessary attributes
+#' @param dt data
+#' @param filepath filepath to save file
+#' @keywords internal
+#' @noRd
+do_write_parquet <- function(dt, filepath){
+  attremove <- grep("^(class|names)$", names(attributes(dt)), value = T, invert = T)
+  for(att in attrmove) data.table::setattr(dt, att, NULL)
+  arrow::write_parquet(dt, sink = filepath, compression = "snappy")
 }
 
 #' @title write_codebooklog


### PR DESCRIPTION
Filegroups are stored as .parquet, and read_filegroup prioritizes to read the .parquet file if existing. read_original_file also gains the ability to read .parquet, to prepare for when orgdata produces such files. 