### PR TITLE
1.0.12

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: khfunctions
 Title: Data processing for FHP/OVP
-Version: 1.0.11.9000
+Version: 1.0.12
 Authors@R: 
     person("Vegard", "Lysne", , "vegard.lysne@helsedir.no", role = c("aut", "cre"))
 Description: What the package does (one paragraph).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: khfunctions
 Title: Data processing for FHP/OVP
-Version: 1.0.11
+Version: 1.0.11.9000
 Authors@R: 
     person("Vegard", "Lysne", , "vegard.lysne@helsedir.no", role = c("aut", "cre"))
 Description: What the package does (one paragraph).

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 ## New features
 * In `LagKUBE()`, moved Rsynt SLUTTREDIGER to after POSTPROSESS
 
+## Bugfix
+* In compute_new_value_from_formula(), the .n column is now set to the maximum of the included .n-columns. Previously it was set to 1. 
+
 # Other changes
 * Improved reporting on 99-codes in `LagFilgruppe`
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# khfunctions (development version)
+
+# Other changes
+* Improved reporting on 99-codes in `LagFilgruppe`
+
 # khfunctions 1.0.11
 
 ## Bugfix

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # khfunctions (development version)
 
+## New features
+* In `LagKUBE()`, moved Rsynt SLUTTREDIGER to after POSTPROSESS
+
 # Other changes
 * Improved reporting on 99-codes in `LagFilgruppe`
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,12 @@
-# khfunctions (development version)
+# khfunctions 1.0.12
 
 ## New features
 * In `LagKUBE()`, moved Rsynt SLUTTREDIGER to after POSTPROSESS
+* `add_crude_rate()` calculates crude RATE and helper columns, replacing compute_new_value_from_formula. 
 
 ## Bugfix
-* In compute_new_value_from_formula(), the .n column is now set to the maximum of the included .n-columns. Previously it was set to 1. 
+* In `compute_new_value_from_formula()`, the .n column is now set to the maximum of the included .n-columns. Previously it was set to 1. 
+* In `estimate_prednevner()`, missing years are filtered out, to ensure match between observed and predicted teller. Otherwise, MEIS was not correct.
 
 # Other changes
 * Improved reporting on 99-codes in `LagFilgruppe`

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,13 @@
-# khfunctions 1.0.12
+# khfunctions 1.0.12 (2025-08-05)
 
 ## New features
 * In `LagKUBE()`, moved Rsynt SLUTTREDIGER to after POSTPROSESS
 * `add_crude_rate()` calculates crude RATE and helper columns, replacing compute_new_value_from_formula. 
+* `control_meis_rate()` added to cube quality control, reports min/max of the MEIS/RATE ratio.
 
 ## Bugfix
 * In `compute_new_value_from_formula()`, the .n column is now set to the maximum of the included .n-columns. Previously it was set to 1. 
-* In `estimate_prednevner()`, missing years are filtered out, to ensure match between observed and predicted teller. Otherwise, MEIS was not correct.
+* In `estimate_prednevner()`, missing years are filtered out to ensure match between observed and predicted teller. Otherwise, MEIS was not correct.
 
 # Other changes
 * Improved reporting on 99-codes in `LagFilgruppe`

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# khfunctions 1.0.12 (2025-08-05)
+# khfunctions 1.0.12 (2025-08-15)
 
 ## New features
 * In `LagKUBE()`, moved Rsynt SLUTTREDIGER to after POSTPROSESS
@@ -12,12 +12,12 @@
 # Other changes
 * Improved reporting on 99-codes in `LagFilgruppe`
 
-# khfunctions 1.0.11
+# khfunctions 1.0.11 (2025-08-13)
 
 ## Bugfix
 * Fixed problem in `do_clean_ALDER` where checks for ALDERl > ALDERh was performed on character columns, not numeric.
 
-# khfunctions 1.0.10 (development version)
+# khfunctions 1.0.10 (2025-08-12)
 
 ## New features
 * Implemented `.parquet`-format. 
@@ -49,40 +49,40 @@
 * Remove all use of `with = FALSE` inside data.table
 * In `LagFilgruppe`, codebooklog and cleanlog is only saved if write = TRUE
 
-# khfunctions 1.0.9
+# khfunctions 1.0.9 (2025-07-02)
 * Fix: cube files was saved with wrong name
 
-# khfunctions 1.0.8
+# khfunctions 1.0.8 (2025-06-26)
 
 * Fixed do_reshape_var when measure.var is not provided and should be all non-id-columns
 * Added Censor_type to parameters
 * Started implementing qualcontrol in LagKUBE, set to inactive until done
 
-# khfunctions 1.0.7
+# khfunctions 1.0.7 (2025-06-24)
 * Critical bugfix in set_recode_filter_filfiltre() when a cube use > 1 FILFILTRE
 * Reactivated FF_RSYNT1 making it possible to add custom R code to a filefilter
 
-# khfunctions 1.0.6
+# khfunctions 1.0.6 (2025-06-23)
 * Critical bugfix when fixing column names pre and post stata handling
 * Added parameter `removebuffer` to LagKUBE, to disable removing of original files during processing. This is useful for dev work, and will be necessary when implementing KUBEFAMILIE which is using the same files.
 
-# khfunctions 1.0.5
+# khfunctions 1.0.5 (2025-06-20)
 * Implemented function `fix_befgk_spelling()` to handle problem with inconsistent spelling of BEF_GK[..], which sometimes appears as BEF_Gk.
 * Fixed bugs in LagFilgruppe where illegal values for INNVKAT was corrected, and illegal values for ALDER was mixed up with AAR. 
 * `analyze_cleanlog()` now only gives a warning if illegal values are found. 
 * Fixed bug when converting column names before STATA export
 
-# khfunctions 1.0.4
+# khfunctions 1.0.4 (2025-06-19)
 * Fixed bugs in setting SPVFLAGG
 * Fixed bugs in friskvik and write_cube_output
 * Fixed bug in year-filter when loading filegroups 
 * Ignore case in KUBER::REFVERDI, allowing both siste and SISTE
 
-# khfunctions 1.0.1
+# khfunctions 1.0.1 (2025-06-17)
 * Fixed predictionfilter to make sure last period is always used for moving averages, and GEOniv=='L' is added if missing in REFVERDI
 * Fix auto-update function
 
-# khfunctions 1.0.0
+# khfunctions 1.0.0 (2025-06-16)
 
 ## Summary of changes overall
 

--- a/R/KHkube.R
+++ b/R/KHkube.R
@@ -30,10 +30,11 @@ LagKUBE <- function(name, write = TRUE, alarm = FALSE, geonaboprikk = TRUE, year
   
   TNF <- merge_teller_nevner(parameters = parameters)
   KUBE <- TNF$TNF
-  if(parameters$TNPinformation$NEVNERKOL != "-") compute_new_value_from_formula(dt = KUBE, formulas = "RATE={TELLER/NEVNER}", post_moving_average = FALSE)
+  # if(parameters$TNPinformation$NEVNERKOL != "-") compute_new_value_from_formula(dt = KUBE, formulas = "RATE={TELLER/NEVNER}", post_moving_average = FALSE)
   organize_file_for_moving_average(dt = KUBE)
   parameters[["MOVAVparameters"]] <- get_movav_information(dt = KUBE, parameters = parameters)
-  KUBE <- aggregate_to_periods(dt = KUBE, reset_rate = TRUE, parameters = parameters)
+  KUBE <- aggregate_to_periods(dt = KUBE, parameters = parameters)
+  add_crude_rate(dt = KUBE, parameters = parameters)
   parameters[["CUBEdesign"]] <- update_cubedesign_after_moving_average(dt = KUBE, origdesign = TNF$KUBEd$MAIN, parameters = parameters)
   
   KUBE <- add_predteller(dt = KUBE, parameters = parameters)

--- a/R/KHkube.R
+++ b/R/KHkube.R
@@ -42,8 +42,6 @@ LagKUBE <- function(name, write = TRUE, alarm = FALSE, geonaboprikk = TRUE, year
   KUBE <- scale_rate_and_meisskala(dt = KUBE, parameters = parameters)
   KUBE <- fix_geo_special(dt = KUBE, parameters = parameters)
 
-  KUBE <- do_special_handling(name = "SLUTTREDIGER", dt = KUBE, code = parameters$CUBEinformation$SLUTTREDIGER, parameters = parameters)
-  
   parameters[["MALTALL"]] <- get_maltall_column(parameters = parameters)
   KUBE <- do_format_cube_columns(dt = KUBE, parameters = parameters)
   KUBE <- add_smr_and_meis(dt = KUBE, parameters = parameters)
@@ -56,6 +54,7 @@ LagKUBE <- function(name, write = TRUE, alarm = FALSE, geonaboprikk = TRUE, year
   
   KUBE <- do_censor_cube(dt = KUBE, parameters = parameters)
   KUBE <- do_special_handling(name = "RSYNT_POSTPROSESS", dt = KUBE, code = parameters$CUBEinformation$RSYNT_POSTPROSESS, parameters = parameters)
+  KUBE <- do_special_handling(name = "SLUTTREDIGER", dt = KUBE, code = parameters$CUBEinformation$SLUTTREDIGER, parameters = parameters)
   
   ALLVIS <- data.table::copy(KUBE)
   ALLVIS <- do_remove_censored_observations(dt = ALLVIS, outvalues = parameters$outvalues)

--- a/R/compute_columns.R
+++ b/R/compute_columns.R
@@ -24,7 +24,8 @@ compute_new_value_from_formula <- function(dt, formulas, post_moving_average = F
     dt[, paste0(name, ".a") := do.call(pmax, c(.SD, list(na.rm = T))), .SDcols = paste0(included_columns, ".a")]
     
     if(post_moving_average){
-      dt[, (paste0(name, c(".n", ".fn1", ".fn3", ".fn9"))) := list(1,0,0,0)]
+      dt[, paste0(name, ".n") := do.call(pmax, c(.SD, list(na.rm = T))), .SDcols = paste0(included_columns, ".n")]
+      dt[, (paste0(name, c(".fn1", ".fn3", ".fn9"))) := list(0,0,0)]
     }  
     dt[is.na(get(name)) | is.infinite(get(name)) | is.nan(get(name)), (paste0(name, c("", ".f"))) := list(NA, 2)]
   }

--- a/R/compute_columns.R
+++ b/R/compute_columns.R
@@ -31,6 +31,22 @@ compute_new_value_from_formula <- function(dt, formulas, post_moving_average = F
   }
 }
 
+add_crude_rate <- function(dt, parameters){
+  if(!"NEVNER" %in% names(dt)){
+    cat("\n** Har ikke NEVNER, kan ikke beregne crude RATE")
+    return(invisible(NULL))
+  } 
+  
+  dt[, let(RATE = TELLER/NEVNER,
+           RATE.f = pmax(TELLER.f, NEVNER.f, na.rm = T),
+           RATE.a = pmax(TELLER.a, NEVNER.a, na.rm = T),
+           RATE.n = pmax(TELLER.n, NEVNER.n, na.rm = T))]
+  
+  if(parameters$MOVAVparameters$is_movav){
+    dt[, (paste0("RATE", c(".fn1", ".fn3", ".fn9"))) := 0]
+  }
+}
+
 #' @title compute_new_value_from_strata_sum
 #' @description
 #' WIP: replacement for LeggTilSumFraRader()

--- a/R/qualcontrol_fg.R
+++ b/R/qualcontrol_fg.R
@@ -33,7 +33,12 @@ analyze_cleanlog <- function(log){
 warn_geo_99 <- function(dt){
   any99 <- dt[grepl("99$", GEO), .N]
   if(any99 > 0){
-    cat("\n**", any99, "99-koder funnet, kodet om fra følgende originalkode(r):", paste(.GlobalEnv$org_geo_codes, collapse = ", "))
+    cat("\n**", any99, "99-koder funnet. ")
+    if(exists("org_geo_codes", envir = .GlobalEnv)){
+      cat("Disse kan være 99 originalt, men er også omkodet fra følgende originalkode(r):", paste(.GlobalEnv$org_geo_codes, collapse = ", "))
+    } else {
+      cat("Disse er ikke omkodet, og har vært 99 originalt.")
+    }
   } else {
     cat("\n** Ingen 99-koder funnet, OK!")
   }

--- a/R/qualcontrol_kube.R
+++ b/R/qualcontrol_kube.R
@@ -6,7 +6,7 @@ control_cube_output <- function(outputlist, parameters){
   all_checks <- c(all_checks, control_censoring(dt = outputlist$QC, parameters = parameters))
   all_checks <- c(all_checks, control_standardization(dt = outputlist$ALLVIS, parameters = parameters))
   all_checks <- c(all_checks, control_aggregation(dt = outputlist$KUBE))
-  
+  control_meis_rate(dt = outputlist$KUBE, parameters = parameters)
   if(sum(all_checks) == 0){
     cat("\n\n---\n* Alle sjekker passert!\n---\n")
   } else {
@@ -123,6 +123,8 @@ compare_geolevels <- function(dt, overcat, undercat, nevner){
   return(0)
 }
 
+#' @keywords internal
+#' @noRd
 compare_kommune_bydel <- function(dt, nevner){
   if(!all(c("B", "K") %in% unique(dt$GEOniv))) return(0)
   byer <- c("0301", "1103", "4601", "5001")
@@ -133,3 +135,12 @@ compare_kommune_bydel <- function(dt, nevner){
   return(out)
 }
 
+#' @keywords internal
+#' @noRd
+control_meis_rate <- function(dt, parameters){
+  cat("\n\n* Sjekker forholdet mellom MEIS og RATE")
+  if(parameters$CUBEinformation$REFVERDI_VP != "P") return(invisible(NULL))
+  cols <- c("MEIS", "RATE")
+  d <- dt[, .SD, .SDcols = cols][, ratio := round(MEIS/RATE, 3)]
+  cat("\n** MEIS/RATE varierer fra", min(d$ratio, na.rm = T), "til", max(d$ratio, na.rm = T))
+}

--- a/R/smr_meis_norm.R
+++ b/R/smr_meis_norm.R
@@ -9,7 +9,6 @@ add_smr_and_meis <- function(dt, parameters){
 #' @keywords internal
 #' @noRd
 calculate_smr_and_meis <- function(dt, parameters){
-  dt[, let(SMR = NA_real_, MEIS = MALTALL, scale_raten = parameters$MOVAVparameters$movav/RATE.n)]
   if(parameters$CUBEinformation$REFVERDI_VP == "P"){
     dt[, let(SMR = sumTELLER / sumPREDTELLER * 100,
              MEIS = sumTELLER / sumPREDTELLER * MEISskala)]

--- a/R/smr_meis_norm.R
+++ b/R/smr_meis_norm.R
@@ -9,10 +9,11 @@ add_smr_and_meis <- function(dt, parameters){
 #' @keywords internal
 #' @noRd
 calculate_smr_and_meis <- function(dt, parameters){
-  dt[, let(SMR = NA_real_, MEIS = MALTALL)]
+  dt[, let(SMR = NA_real_, MEIS = MALTALL, scale_raten = parameters$MOVAVparameters$movav/RATE.n)]
   if(parameters$CUBEinformation$REFVERDI_VP == "P"){
     dt[, let(SMR = sumTELLER / sumPREDTELLER * 100,
              MEIS = sumTELLER / sumPREDTELLER * MEISskala)]
+    dt[sumPREDTELLER == 0, let(SMR = NA, MEIS = NA)]
   }
   return(dt)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -24,7 +24,7 @@ get_value_columns <- function(columnnames, full = FALSE) {
 #' @keywords internal
 #' @noRd
 get_dimension_columns <- function(columnnames) {
-  nodim <- c(get_value_columns(columnnames, full = TRUE), "KOBLID", "ROW")
+  nodim <- c(get_value_columns(columnnames, full = TRUE), "KOBLID", "ROW", "missyear")
   return(setdiff(columnnames, nodim))
 }
 


### PR DESCRIPTION

## New features
* In `LagKUBE()`, moved Rsynt SLUTTREDIGER to after POSTPROSESS
* `add_crude_rate()` calculates crude RATE and helper columns, replacing compute_new_value_from_formula. 
* `control_meis_rate()` added to cube quality control, reports min/max of the MEIS/RATE ratio.

## Bugfix
* In `compute_new_value_from_formula()`, the .n column is now set to the maximum of the included .n-columns. Previously it was set to 1. 
* In `estimate_prednevner()`, missing years are filtered out to ensure match between observed and predicted teller. Otherwise, MEIS was not correct.

# Other changes
* Improved reporting on 99-codes in `LagFilgruppe`