### PR TITLE
Håndtere single lks-koder

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: khfunctions
 Title: Data processing for FHP/OVP
-Version: 1.2.5
+Version: 1.2.6
 Authors@R: 
     person("Vegard", "Lysne", , "vegard.lysne@helsedir.no", role = c("aut", "cre"))
 Description: What the package does (one paragraph).
@@ -26,7 +26,7 @@ Imports:
     data.table (>= 1.17.8),
     arrow (>= 23.0.0),
     dplyr (>= 1.1.4),
-    duckdb (>= 1.4.2),
+    duckdb (>= 1.5.5),
     DBI (>= 1.2.3),
     parallel
 Suggests: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# khfunctions 1.2.6 (2026-08-04)
+
+- Added function to handle bydel/kommune levels with single lks. LKS is added as a copy of the parent level. For invalid zones which is not a single zone, a censored copy of the parent level is added. ([issue170](https://github.com/helseprofil/khfunctions/issues/170))
+- Increased min version of duckdb to 1.5.5 due to new functionality.
+
 # khfunctions 1.2.5 (2026-06-16)
 
 - Critical bugfix in censoring, which did not remove numbers if censoring was turned off. Numbers are still removed for other reasons, e.g. LKS_STARTAAR, and need to get the appropriate SPVFLAGG. 

--- a/R/KHkube.R
+++ b/R/KHkube.R
@@ -67,6 +67,7 @@ LagKUBE <- function(name, write = TRUE, alarm = FALSE, geonaboprikk = TRUE, year
   # 7. Postprosess og sluttrediger - manuelle/eksterne kodesnutter
   KUBE <- do_special_handling(name = "RSYNT_POSTPROSESS", dt = KUBE, dt_name = "KUBE", code = parameters$CUBEinformation$RSYNT_POSTPROSESS, parameters = parameters)
   KUBE <- do_special_handling(name = "SLUTTREDIGER", dt = KUBE, dt_name = "KUBE", code = parameters$CUBEinformation$SLUTTREDIGER, parameters = parameters)
+  KUBE <- add_missing_lks(dt = KUBE, parameters = parameters)
   
   # 8. Slicing av outputfiler
   RESULTAT <- list(KUBE = KUBE)

--- a/R/duckdb_utils.R
+++ b/R/duckdb_utils.R
@@ -8,7 +8,7 @@ init_duckdb <- function(dbname){
   db <- file.path(tmpdir, paste0(dbname, ".duckdb"))
   if(file.exists(db)){
     try({
-      con_tmp <- DBI::dbConnect(duckdb::duckdb(), dbdir = db)
+      con_tmp <- DBI::dbConnect(duckdb::duckdb(shared_home = FALSE), dbdir = db)
       DBI::dbDisconnect(con_tmp, shutdown = TRUE)
     }, silent = TRUE)
     
@@ -17,7 +17,7 @@ init_duckdb <- function(dbname){
       db,paste0(db, ".wal"),paste0(db, ".tmp")
     ))])
   }
-  DBI::dbConnect(duckdb::duckdb(), dbdir = db)
+  DBI::dbConnect(duckdb::duckdb(shared_home = FALSE), dbdir = db)
 }
 
 #' @title do_clean_duckdb

--- a/R/geo_handling.R
+++ b/R/geo_handling.R
@@ -150,3 +150,39 @@ get_deletestrata <- function(dt, dims, level){
   delete <- collapse::join(deletestrata, deletecodes, on = "overniv", multiple = TRUE, verbose = FALSE, overid = 2)[, .SD, .SDcols = dims]
   return(delete)
 }
+
+#' @title add_missing_lks
+#' @param dt 
+#' @param parameters 
+#' @noRd
+add_missing_lks <- function(dt, parameters){
+  if(!"V" %in% unlist(strsplit(parameters$CUBEinformation$GEOniv, ","))) return(invisible(NULL))
+  
+  # Legg til soner for kommuner med bare en sone
+  single <- data.table::data.table(lks = parameters$GeoKoder[GEOniv == "V", unique(GEO)])
+  single[, overniv := sub("00$", "", substr(lks, 1, 6))]
+  single[, N := .N, by = overniv]
+  single <- single[N == 1]
+  if(nrow(single) > 0){
+    add_single <- dt[GEO %in% single$overniv]
+    data.table::set(add_single, j = "GEOniv", value = "V")
+    add_single[single, on = setNames("overniv", "GEO"), GEO := lks]
+    } else {
+      add_single <- dt[0]
+    }
+  
+  # Legg til ugyldige soner, som skal eksistere men være prikket
+  invalid <- data.table::data.table(lks = parameters$GeoKoder[GEOniv == "V" & TYP == "U" & !GEO %in% unique(add_single[["GEO"]]), unique(GEO)])
+  if(nrow(invalid) > 0){
+    invalid[, overniv := sub("00$", "", substr(lks, 1, 6))]
+    add_invalid <- dt[GEO %in% invalid$overniv]
+    data.table::set(add_invalid, j = "GEOniv", value = "V")
+    add_invalid[invalid, on = setNames("overniv", "GEO"), GEO := lks]
+    add_invalid[, let(spv_tmp = 1, geoprikket = 1)]
+    } else {
+      add_invalid <- dt[0]
+    }
+  
+  dt <- data.table::rbindlist(list(dt, add_single, add_invalid))
+  return(dt)
+}

--- a/R/geo_handling.R
+++ b/R/geo_handling.R
@@ -178,7 +178,9 @@ add_missing_lks <- function(dt, parameters){
     add_invalid <- dt[GEO %in% invalid$overniv]
     data.table::set(add_invalid, j = "GEOniv", value = "V")
     add_invalid[invalid, on = setNames("overniv", "GEO"), GEO := lks]
-    add_invalid[, let(spv_tmp = 1, geoprikket = 1)]
+    add_invalid[, let(spv_tmp = 2, geoprikket = 1)]
+    vals <- union(get_value_columns(names(dt)), c("sumTELLER", "sumNEVNER", "MEIS", "RATE", "SMR"))
+    data.table::set(add_invalid, j = vals, value = NA)
     } else {
       add_invalid <- dt[0]
     }


### PR DESCRIPTION
For kommuner/bydeler med bare en levekårssone vil vi at disse skal få tall, men at de skal være en kopi av kommunetallet slik at ikke ukjent grunnkrets gjør at kommune og lks får litt ulike tall. 